### PR TITLE
Updated to use minphp/session version 1.1.

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,9 @@ following elements are required to be set:
         - `tbl_id` *string* The ID database field
         - `tbl_exp` *string* The expiration database field
         - `tbl_val` *string* The value database field
+        - `ttl` *int* The session time-to-live, in seconds, relative to current
+server time (should be set to the same value as the other TTLs, e.g.,
+'max(ttl, cookie_ttl)' to correctly sync client and server session expirations)
     - `ttl` *int* Number of seconds to keep a session alive.
     - `cookie_ttl` *int* Number of seconds to keep long storage cookie alive.
     - `session_name` *string* Name of the session.

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "minphp/language": "^1.1",
         "minphp/pagination": "^1.0",
         "minphp/record": "^2.0",
-        "minphp/session": "^1.0",
+        "minphp/session": "^1.1",
         "minphp/xml": "^1.0"
     },
     "require-dev": {


### PR DESCRIPTION
Updated the Session component to set a second cookie and keep-alives similar to minphp 0.x. The second cookie piggy-backs the default php session cookie (same session ID) as it did in minphp 0.x.
Both the default php session cookie and this second cookie share the same TTL--effectively 'remember me' support similar to minphp 0.x.
Fixes #7