### PR TITLE
Init with a default CSRF token key

### DIFF
--- a/src/Helpers/Form.php
+++ b/src/Helpers/Form.php
@@ -10,5 +10,16 @@ use Minphp\Form\Form as MinphpForm;
  */
 class Form extends MinphpForm
 {
-
+    /**
+     * Init
+     */
+    public function __construct()
+    {
+        // Minphp/Form differs from the original Form component in minPHP 0.x such
+        // that null token key's (the default behavior) is converted to use a form's
+        // action, or the request URI, as the key for verification. Thus, it is now
+        // required to call Form::setCsrfOptions to set a non-null key in order to
+        // maintain backward compatibility with default behavior (a null key).
+        $this->setCsrfOptions(['token_key' => '7nE4=3lXeu;K80l?v_F06Eh28JS>L;:1']);
+    }
 }


### PR DESCRIPTION
This allows the form to be backward compatible without specifying a CSRF token key, as was the case in minphp 0.x
Fixes #13